### PR TITLE
[feat] Add new chat member greeting and update dotenv loading logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,8 @@
         "files": [
           "src/app/Utils/functions/helpers.php"
         ]
+    },
+    "scripts": {
+        "start": "php src/index.php"
     }
 }

--- a/src/app/Telegram/telegram.php
+++ b/src/app/Telegram/telegram.php
@@ -22,3 +22,37 @@ $bot->onCommand('version', VersionConversation::class);
 
 // callback queries
 $bot->onCallbackQueryData("page {page}", VersionConversation::class);
+
+$bot->onNewChatMembers(function (Nutgram $bot) {
+    $message = $bot->message();
+    if ($message === null) {
+        return;
+    }
+
+    $chatType = $message->chat->type->name ?? null;
+    if (!in_array($chatType, ['GROUP', 'SUPERGROUP'], true)) {
+        return;
+    }
+
+    $names = [];
+    foreach ($message->new_chat_members as $user) {
+        if (!empty($user->is_bot) && $user->is_bot) {
+            continue;
+        }
+        $names[] = $user->first_name;
+    }
+
+    if (empty($names)) {
+        return;
+    }
+
+    $text = '👋 Assalomu alaykum, ' . implode(', ', $names) . "!";
+    $text .= "\nPHP dasturchilar hamjamiyatiga xush kelibsiz!";
+    $text .= "\n📜 Qoidalar: /rules";
+    $text .= "\n🔗 Foydali resurslar: /useful";
+    $text .= "\n🗺️ Yo'l xaritasi: /roadmap";
+    $text .= "\n Boshqa buyruqlarni @phpuz_bot ga yuboring.";
+
+
+    $bot->sendMessage($text, reply_to_message_id: $message->message_id);
+});

--- a/src/app/Utils/functions/helpers.php
+++ b/src/app/Utils/functions/helpers.php
@@ -3,10 +3,15 @@
 use Dotenv\Dotenv;
 
 function env(string $key, $default = null) {
-    $dotenv = Dotenv::createImmutable(__DIR__ . '/../../../../');
-    $dotenv->load();
+    static $loaded = false;
+    if (!$loaded) {
+        $dotenv = Dotenv::createImmutable(__DIR__ . '/../../../../');
+        $dotenv->safeLoad();
+        $loaded = true;
+    }
+
     $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
-    if ($value === false) {
+    if ($value === false || $value === null || $value === '') {
         return $default;
     }
     return $value;


### PR DESCRIPTION
This pull request introduces a new welcome message for new group chat members in the Telegram bot, improves the environment variable loading logic, and adds a convenient script to start the application. The most important changes are grouped below:

**Telegram Bot Enhancements:**

* Added a handler in `telegram.php` to send a personalized welcome message to new non-bot members joining group or supergroup chats, including community rules and resources.

**Environment Variable Handling:**

* Improved the `env` function in `helpers.php` to safely load environment variables only once using `safeLoad()`, and to return the default value if the variable is unset, null, or empty.

**Developer Experience:**

* Added a `start` script to `composer.json` to easily run the application with `php src/index.php`.